### PR TITLE
Start building armv7l wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -383,6 +383,7 @@ jobs:
         - aarch64
         - ppc64le
         - s390x
+        - armv7l
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       qemu: ${{ matrix.qemu }}

--- a/CHANGES/5.misc.rst
+++ b/CHANGES/5.misc.rst
@@ -1,0 +1,1 @@
+Added ``armv7l`` wheels -- by :user:`bdraco`.


### PR DESCRIPTION
https://github.com/pypa/cibuildwheel/releases/tag/v2.21.2 now supports armv7l on musl