### PR TITLE
Fix docs url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ The module provides a fast implementation of cached properties for Python 3.8+.
 
 
 .. image:: https://readthedocs.org/projects/propcache/badge/?version=latest
-    :target: https://propcache.aio-libs.org
+    :target: https://propcache.readthedocs.io
 
 
 .. image:: https://img.shields.io/pypi/pyversions/propcache.svg
@@ -36,7 +36,7 @@ The API is designed to be nearly identical to the built-in ``functools.cached_pr
 except for the additional ``under_cached_property`` class which uses ``self._cache``
 instead of ``self.__dict__`` to store the cached values and prevents ``__set__`` from being called.
 
-For full documentation please read https://propcache.aio-libs.org.
+For full documentation please read https://propcache.readthedocs.io.
 
 Installation
 ------------
@@ -69,7 +69,7 @@ by this variable.
 API documentation
 ------------------
 
-The documentation is located at https://propcache.aio-libs.org.
+The documentation is located at https://propcache.readthedocs.io.
 
 Source code
 -----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,8 @@ project_urls =
   CI: GitHub Workflows = https://github.com/aio-libs/propcache/actions?query=branch:master
   Code of Conduct = https://github.com/aio-libs/.github/blob/master/CODE_OF_CONDUCT.md
   Coverage: codecov = https://codecov.io/github/aio-libs/propcache
-  Docs: Changelog = https://propcache.aio-libs.org/en/latest/changes/
-  Docs: RTD = https://propcache.aio-libs.org
+  Docs: Changelog = https://propcache.readthedocs.io/en/latest/changes/
+  Docs: RTD = https://propcache.readthedocs.io
   GitHub: issues = https://github.com/aio-libs/propcache/issues
   GitHub: repo = https://github.com/aio-libs/propcache
 description = Accelerated property cache


### PR DESCRIPTION
Eventually the goal is to get propcache.aio-libs.org up and going but in the mean time propcache.readthedocs.io already works