### PR TITLE
Remove reference to alpine linux from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,8 @@ Installation
 The library is Python 3 only!
 
 PyPI contains binary wheels for Linux, Windows and MacOS.  If you want to install
-``propcache`` on another operating system (like *Alpine Linux*, which is not
-manylinux-compliant because of the missing glibc and therefore, cannot be
-used with our wheels) the the tarball will be used to compile the library from
+``propcache`` on another operating system where wheels are not provided,
+the the tarball will be used to compile the library from
 the source code. It requires a C compiler and and Python headers installed.
 
 To skip the compilation you must explicitly opt-in by using a PEP 517


### PR DESCRIPTION
We provide musllinux wheels now so the readme no longer made sense